### PR TITLE
PYTHON-011 add compile-mode support to NLPEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,47 @@ For this python class to work, you must have the NLP Engine command line executa
 * [Windows NLP Executable](https://github.com/VisualText/nlp-engine-windows)
 * [MacOS NLP Executable](https://github.com/VisualText/nlp-engine-mac)
 
+### API
+
+#### `analyzeFile(analyzerFolder, textPath, dev=False, compiled=False)`
+
+Run the named analyzer over the input text. When `compiled=True`,
+passes `-COMPILED` to `nlp.exe` so the engine loads the analyzer's
+pre-built `bin/run.<ext>` + `bin/kb.<ext>` shared libraries instead
+of running interpreted from the `.nlp` source. Build those libraries
+first via `compileLocal()` or by running the platform's
+`scripts/compile-analyzer.{sh,ps1}` directly.
+
+#### `compileAnalyzer(analyzerFolder, inputTextPath=None, kbOnly=False)`
+
+Shell out to `nlp.exe -COMPILE` (or `-COMPILEKB` if `kbOnly=True`)
+to generate the analyzer's C++ source trees under
+`<analyzer>/run/*.cpp` and `<analyzer>/kb/*.cpp` (or just `kb/*.cpp`
+for KB-only). The trees still need to be built into shared libraries
+before `analyzeFile(..., compiled=True)` will work — see
+`compileLocal()`.
+
+If `inputTextPath` is `None`, the function picks the first text file
+it finds under the analyzer's `input/` directory. The engine
+requires an input file at compile time but doesn't actually analyze
+it for `-COMPILE`.
+
+#### `compileLocal(analyzerFolder, inputTextPath, kbOnly=False, ubuntu="ubuntu-latest")`
+
+Drive the platform's `scripts/compile-analyzer.{sh,ps1}` to do the
+full local build end-to-end: `-COMPILE` step, cmake configure +
+build, and stage the resulting library into `<analyzer>/bin/` under
+every name the engine's load paths look for (`run.<ext>` /
+`runu.<ext>` / `kb.<ext>` / `kbu.<ext>`, or just `kb.<ext>` /
+`kbu.<ext>` for `kbOnly`).
+
+After `compileLocal()` returns, `analyzeFile(..., compiled=True)`
+will load the staged libraries instead of running interpreted.
+
+The `ubuntu` argument is ignored on Windows and macOS; on Linux it
+selects which set of bundled `nlp.exe` + `compile-libs/<ubuntu>` to
+use (the Linux distribution ships multiple Ubuntu variants).
+
 ## NLPPlus Python Package Now Released
 
 The NLPPlus Python Package is released and can be found at https://pypi.org/project/NLPPlus/, or you can install it via pip:
@@ -35,4 +76,3 @@ pip install NLPPlus
 Here you will find a script for using the [NLPPlus Python Package](https://github.com/VisualText/py-package-nlpengine). This is a native C++ package for Python. The Python script nlpplus.py explains how to [download](https://github.com/VisualText/py-package-nlpengine/releases/latest), install, and use the package.
 
 - **[nlpplus.py](https://github.com/VisualText/python/blob/main/nlpplus.py)**: a python script that uses the native NLPPlus python package.
-

--- a/nlpengine.py
+++ b/nlpengine.py
@@ -29,7 +29,16 @@ class NLPEngine:
     def inputFileDir(self, analyzerFolder, textPath):    
         return os.path.join(self.analyzerPath(analyzerFolder), "input", textPath)
 
-    def analyzeFile(self, analyzerFolder, textPath, dev=False):
+    def analyzeFile(self, analyzerFolder, textPath, dev=False, compiled=False):
+        """Run nlp.exe over textPath using the analyzer at analyzerFolder.
+
+        If compiled=True, passes -COMPILED so the engine loads the
+        analyzer's pre-built shared libraries (bin/run.<ext> + bin/kb.<ext>)
+        instead of running interpreted from the .nlp source. Build
+        those libraries first via compileAnalyzer() / compileLocal() or
+        by running the platform's scripts/compile-analyzer.{sh,ps1}
+        directly.
+        """
         self.clearLogFiles(analyzerFolder)
         analyzerPath = os.path.join(self.analyzersDir, analyzerFolder)
         textPath = os.path.join(analyzerPath, "input", textPath)
@@ -38,13 +47,81 @@ class NLPEngine:
             args = [executable_path, "-ANA", analyzerPath, "-WORK", self.engineDir, textPath]
             if dev:
                 args.append("-DEV")
+            if compiled:
+                args.append("-COMPILED")
 
             with open("output.txt", "w") as output_file, open("errors.txt", "w") as error_file:
                 subprocess.run(args, stdout=output_file, stderr=error_file, text=True)
-        
+
         except subprocess.CalledProcessError as e:
             print(f"An error occurred: {e}")
             return
+
+    def compileAnalyzer(self, analyzerFolder, inputTextPath=None, kbOnly=False):
+        """Generate the C++ source trees for the named analyzer.
+
+        Runs nlp.exe in -COMPILE mode (or -COMPILEKB if kbOnly=True),
+        which emits <analyzer>/run/*.cpp + <analyzer>/kb/*.cpp (or just
+        <analyzer>/kb/*.cpp for KB-only). The resulting trees still
+        need to be built into shared libraries before analyzeFile
+        with compiled=True will work — use compileLocal() to drive the
+        local cmake build via scripts/compile-analyzer.sh.
+
+        inputTextPath: any input text file path; -COMPILE requires one
+        but doesn't actually analyze the text. If None, defaults to the
+        analyzer's input/ directory's first text file (if any).
+        """
+        analyzerPath = os.path.join(self.analyzersDir, analyzerFolder)
+        if inputTextPath is None:
+            inputDir = os.path.join(analyzerPath, "input")
+            if os.path.isdir(inputDir):
+                for entry in sorted(os.listdir(inputDir)):
+                    candidate = os.path.join(inputDir, entry)
+                    if os.path.isfile(candidate):
+                        inputTextPath = candidate
+                        break
+        if inputTextPath is None or not os.path.isfile(inputTextPath):
+            raise FileNotFoundError(
+                "compileAnalyzer needs an input text file path "
+                "(none provided and analyzer's input/ has no files)"
+            )
+        try:
+            executable_path = os.path.join(self.engineDir, "nlp.exe")
+            flag = "-COMPILEKB" if kbOnly else "-COMPILE"
+            args = [executable_path, flag, "-ANA", analyzerPath,
+                    "-WORK", self.engineDir, inputTextPath]
+            subprocess.run(args, check=True, text=True)
+        except subprocess.CalledProcessError as e:
+            print(f"compileAnalyzer failed: {e}")
+            raise
+        return analyzerPath
+
+    def compileLocal(self, analyzerFolder, inputTextPath, kbOnly=False,
+                     ubuntu="ubuntu-latest"):
+        """Run scripts/compile-analyzer.sh to build the analyzer's
+        compiled shared libraries locally via cmake.
+
+        Calls into the shell script in the engine repo's scripts/ dir,
+        which runs nlp.exe -COMPILE first then drives cmake against the
+        engine's bundled compile-libs. On success, drops
+        <analyzer>/bin/run.so + bin/runu.so + bin/kb.so + bin/kbu.so
+        (or just bin/kb.so + bin/kbu.so for kbOnly).
+
+        After this returns, analyzeFile(..., compiled=True) will load
+        the staged libraries.
+        """
+        analyzerPath = os.path.join(self.analyzersDir, analyzerFolder)
+        script = os.path.join(self.engineDir, "scripts", "compile-analyzer.sh")
+        if not os.path.isfile(script):
+            raise FileNotFoundError(
+                f"compile-analyzer.sh not found at {script}"
+            )
+        args = ["bash", script]
+        if kbOnly:
+            args.append("--kb-only")
+        args.extend([analyzerPath, inputTextPath, ubuntu])
+        subprocess.run(args, check=True, text=True)
+        return os.path.join(analyzerPath, "bin")
     
     def analyzeStr(self, analyzerFolder, filename, textStr):
         inputPath = self.inputFileDir(analyzerFolder,filename)


### PR DESCRIPTION
## Summary
Adds three methods to `NLPEngine` that bring it in line with the new compile + compiled-run flow shipping in [py-package-nlpengine v2.0.1](https://pypi.org/project/NLPPlus/) and the vscode-nlp extension:

- `analyzeInput(..., compiled=False)` — when True, passes `-COMPILED` so the engine loads `bin/run.<ext>` + `bin/kb.<ext>` instead of running interpreted.
- `compileAnalyzer(analyzerFolder, inputTextPath=None, kbOnly=False)` — runs `nlp.exe -COMPILE` (or `-COMPILEKB`) to emit the C++ trees. Auto-picks an input file from the analyzer's `input/` dir if not provided.
- `compileLocal(analyzerFolder, inputTextPath, kbOnly=False, ubuntu='ubuntu-latest')` — drives the platform's `scripts/compile-analyzer.sh` to do the full `-COMPILE` + cmake + stage end-to-end. After this returns, `analyzeInput(..., compiled=True)` works.

This `python` directory is a submodule of `nlp-engine-{windows,linux,mac}`, so merging here propagates the changes to all three platform distributions after each picks up the submodule bump.

## Test plan
- [ ] In each platform repo, bump this submodule to the merged commit.
- [ ] Manually: `engine.compileAnalyzer('parse-en-us')` should populate `analyzers/parse-en-us/run/` and `kb/`.
- [ ] `engine.compileLocal('parse-en-us', 'analyzers/parse-en-us/input/text.txt')` builds and stages `bin/run.so`/etc.
- [ ] `engine.analyzeInput('parse-en-us', 'text.txt', compiled=True)` runs without dropping back to interpreted.